### PR TITLE
Swap homepage Blog and Projects sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -82,23 +82,7 @@ const designs: CollectionEntry<"design">[] = (await getCollection("design"))
   </section>
 
   <section class="mx-auto max-w-xl p-4">
-    <h2 class="mt-6 font-semibold">
-      <a href="/blog/">Blog</a>
-    </h2>
-
-    {
-      posts.map((post) => (
-        <a href={`/blog/${post.id}/`} class="my-4 flex font-medium">
-          {post.data.title}
-        </a>
-      ))
-    }
-
-    <a href="/blog/" class="flex font-medium">
-      <span>Read More {" "}{"-->"}</span>
-    </a>
-
-    <h2 class="mt-20 font-semibold">Projects</h2>
+    <h2 class="mt-6 font-semibold">Projects</h2>
 
     <section id="projects" class="my-6 space-y-5">
       <a
@@ -1152,6 +1136,22 @@ const designs: CollectionEntry<"design">[] = (await getCollection("design"))
         >
       </a>
     </section>
+
+    <h2 class="mt-20 font-semibold">
+      <a href="/blog/">Blog</a>
+    </h2>
+
+    {
+      posts.map((post) => (
+        <a href={`/blog/${post.id}/`} class="my-4 flex font-medium">
+          {post.data.title}
+        </a>
+      ))
+    }
+
+    <a href="/blog/" class="flex font-medium">
+      <span>Read More {" "}{"-->"}</span>
+    </a>
 
     <h2 class="mt-20 font-semibold">Newsletter</h2>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Puts the Projects section above the Blog list on the home page so recent work is more prominent. Newsletter stays last.

- Projects heading uses the original first-section spacing (`mt-6`)
- Blog heading uses the original second-section spacing (`mt-20`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ea83d71-a18e-49f2-be7e-882964c4a0b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ea83d71-a18e-49f2-be7e-882964c4a0b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

